### PR TITLE
Implement stricter input checking on gauge-sweep scripts

### DIFF
--- a/python/gauge-sweep.py
+++ b/python/gauge-sweep.py
@@ -3,10 +3,20 @@
 #
 import serial
 import time
+import sys
 ser = serial.Serial('/dev/ttyUSB0', 57600, timeout=0)
 out = ser.read(100)
 print (out)
-var = input("Enter O to start: ")
+
+var = ""
+while "O" not in var:
+    var = input("Enter [letter] O to start or Q to quit: ")
+
+    if 'Q' in var:
+        print("Exiting")
+        ser.close()
+        sys.exit(0)
+
 ser.write('S4'.encode())
 ser.write('\r'.encode())
 time.sleep(0.1)

--- a/python/gauge-sweep2.py
+++ b/python/gauge-sweep2.py
@@ -3,10 +3,20 @@
 #
 import serial
 import time
+import sys
 ser = serial.Serial('/dev/ttyUSB0', 500000, timeout=0)
 out = ser.read(100)
 print (out)
-var = raw_input("Enter O to start: ")
+
+var = ""
+while "O" not in var:
+    var = raw_input("Enter [letter] O to start or Q to quit: ")
+
+    if 'Q' in var:
+        print("Exiting")
+        ser.close()
+        sys.exit(0)
+
 ser.write('S4')
 ser.write('\r')
 ser.write(var)


### PR DESCRIPTION
Time was being lost by a number of groups in BSides London workshops
where these scripts were used mistaking numeric 0 for the letter O.

Since the start sequence input is also interpolated into serial commands
to the arduino CAN sketch and no checking is performed this results in
a very busy looking arduino and no actions taking place on the cluster.

Prevent the scripts from continuing without the required inputs and implement
a clean exit functionality to neatly close the serial port.